### PR TITLE
Fix issue with double digit year being mapped to 19xx

### DIFF
--- a/src/convert/utc-date.js
+++ b/src/convert/utc-date.js
@@ -1,9 +1,13 @@
 function getUnixTimeFromUTC ({ year, month, day, hours, minutes, seconds = 0, milliseconds = 0 }) {
-  return Date.UTC(year, month - 1, day, hours, minutes, seconds, milliseconds)
+  const date = new Date(Date.UTC(year, month - 1, day, hours, minutes, seconds, milliseconds))
+  date.setFullYear(year)
+  return date.getTime()
 }
 
 function getDateFromTime ({ year, month, day, hours, minutes, seconds = 0, milliseconds = 0 }) {
-  return new Date(year, month - 1, day, hours, minutes, seconds, milliseconds)
+  const date = new Date(year, month - 1, day, hours, minutes, seconds, milliseconds)
+  date.setFullYear(year)
+  return date
 }
 
 function getUTCTime (date) {


### PR DESCRIPTION
Currently there is no way to create a time between year `01-99` since they will be mapped to `19xx` instead.

For example:
```js
const { findTimeZone, getZonedTime, getUnixTime } = require('timezone-support')

const time = { year: 1, month: 5, day: 7, hours: 0, minutes: 0 };
new Date(getUnixTime(time, findTimeZone('Europe/Berlin')))
// 1901-05-06T23:00:00.000Z
```

I would expect the result to be `0001-05-06T23:00:00.000Z` instead.

This PR should fix this issue by utilising `setFullYear` on the created date.