### PR TITLE
Moving moment-timezone to general dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5556,14 +5556,12 @@
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moment-timezone": {
-      "version": "0.5.25",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.25.tgz",
-      "integrity": "sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==",
-      "dev": true,
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.26.tgz",
+      "integrity": "sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==",
       "requires": {
         "moment": ">= 2.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     }
   },
   "dependencies": {
-    "commander": "2.20.0"
+    "commander": "2.20.0",
+    "moment-timezone": "^0.5.26"
   },
   "devDependencies": {
     "@babel/core": "7.4.5",
@@ -109,7 +110,6 @@
     "i": "0.3.6",
     "jasmine-core": "3.4.0",
     "jest": "24.8.0",
-    "moment-timezone": "0.5.25",
     "npm": "6.9.0",
     "npm-run-all": "4.1.5",
     "puppeteer": "1.17.0",

--- a/util/data-creator.js
+++ b/util/data-creator.js
@@ -1,5 +1,5 @@
 const { outputFile: writeFile } = require('fs-extra')
-const tz = require('../node_modules/moment-timezone/moment-timezone-utils').tz
+const tz = require('moment-timezone/moment-timezone-utils').tz
 const groupLeaders = require('./data/group-leaders.json')
 const unpackedTimeZoneData = require('./data/unpacked.json')
 const packedTimeZoneData = require('./data/packed.json')


### PR DESCRIPTION
I tried using `create-timezone-data` just installed `timezone-support`. However due to the way `moment-timezone` is being required in `utils/data-creator.js` and installed only as a development dependency I get an error:

```
internal/modules/cjs/loader.js:596
    throw err;
    ^

Error: Cannot find module '../node_modules/moment-timezone/moment-timezone-utils'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:594:15)
```

Since `moment-timezone` is not loaded in the main code, this should have no impact on `timezone-support` packaging in projects that use it, just as it does not have with `commander` anymore.

Another option for this PR would be to create a separate project for data generation.