### PR TITLE
Fix getUnixTime across dst

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "rollup-plugin-cleanup": "3.2.1",
     "rollup-plugin-swc-minify": "1.0.5",
     "serve-static": "1.15.0",
-    "timezone-support": "link:",
+    "timezone-support": "file:",
     "typescript": "4.9.3"
   },
   "keywords": [

--- a/src/convert/convert.js
+++ b/src/convert/convert.js
@@ -48,17 +48,25 @@ function getUnixTime (time, timeZone) {
     return epoch
   }
   const unixTime = getUnixTimeFromUTC(time)
+  let convertedUnixTime;
   if (zone) {
     if (timeZone) {
       throw new Error('Both own and other time zones specified. Omit the other one.')
     }
+    convertedUnixTime = unixTime + zone.offset * 60000
   } else {
     if (!timeZone) {
       throw new Error('Missing other time zone.')
     }
     zone = getTransition(unixTime, timeZone)
+    convertedUnixTime = unixTime + zone.offset * 60000
+    const convertedZoneOffset = getTransition(convertedUnixTime, timeZone).offset
+    // check if the converted date may have moved to a different offset (probably because of a DST switch)
+    if (convertedZoneOffset !== zone.offset) {
+      convertedUnixTime = unixTime + convertedZoneOffset * 60000
+    }
   }
-  return unixTime + zone.offset * 60000
+  return convertedUnixTime
 }
 
 function setTimeZone (time, timeZone, options) {

--- a/test/getUnixTime.test.js
+++ b/test/getUnixTime.test.js
@@ -84,6 +84,24 @@ it('recognizes daylight-saving time', () => {
   expect(unixTime).toEqual(epoch)
 })
 
+it('recognizes daylight-saving time switch point of explicit timezone', () => {
+  // This test depends on what local TZ it is being executed in!!!
+  // The local TZ has to be at least 2 hours closer to UTC than Melbourne
+  // The TZ where this has been confirmed was UTC+3 (Europe/Sofia)
+  // This test shall fail without the fix because the UTC moment is after the DST switch and the target moment is before that
+  const melbourneTime = {
+    year: 2023,
+    month: 10,
+    day: 1,
+    hours: 0,
+    minutes: 0
+  }
+  const unixTime = getUnixTime(melbourneTime, findTimeZone('Australia/Melbourne'))
+  expect(typeof unixTime === 'number').toBeTruthy()
+  const epoch = Date.UTC(2023, 8, 30, 14, 0)
+  expect(unixTime).toEqual(epoch)
+})
+
 it('checks, that other time zone is specified, if required', () => {
   const berlinTime = {
     year: 2018,


### PR DESCRIPTION
This one is related to prantlf/date-fns-timezone#24 and fixes the same issue when converting a date which has its timestamp on one side of the DST switch point but the converted date in the target timezone is to be on the other side.

It also sounds like the same issue described in #33 